### PR TITLE
Boton de ayuda de navegador

### DIFF
--- a/Codigo/Componentes/Navegador2_5/Capa_Vista_Navegador/Navegador.cs
+++ b/Codigo/Componentes/Navegador2_5/Capa_Vista_Navegador/Navegador.cs
@@ -2595,41 +2595,97 @@ namespace Capa_Vista_Navegador
             }
         }
 
+        //****************************************************** modificado por Kateryn De Leon (30/01/2025)************************************************
+        // Declarar el ToolTip en el botón de Ayuda
+        private ToolTip toolTipAyuda = new ToolTip();
+
         private void Btn_Ayuda_Click(object sender, EventArgs e)
+        {
+
+            // Busca la carpeta raíz del proyecto llamada proyectois2k25 a partir de la ruta del ejecutable.
+            // Si encuentra la carpeta, busca el archivo AyudaNavegador.chm dentro de ella y sus subcarpetas.
+            //Si el archivo es encontrado, intenta abrirlo usando Help.ShowHelp().Si falla, lo abre directamente con el proceso del sistema.
+
+
+            // Mostrar el ToolTip en el botón de ayuda
+            toolTipAyuda.SetToolTip(Btn_Ayuda, "Documento de ayuda");
+
+            // Obtener la ruta del ejecutable
+            string sExecutablePath = AppDomain.CurrentDomain.BaseDirectory;
+
+            // Buscar la carpeta raíz "proyectois2k25" desde el ejecutable
+            string sProjectPath = sFindProjectRootDirectory(sExecutablePath, "proyectois2k25");
+
+            if (string.IsNullOrEmpty(sProjectPath))
+            {
+                MessageBox.Show("❌ ERROR: No se encontró la carpeta 'proyectois2k25'", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            // Buscar el archivo AyudaNavegador.chm en la carpeta raíz y subcarpetas
+            string sPathAyuda = sfunFindFileInDirectory(sProjectPath, "AyudaNavegador.chm");
+
+            // Si el archivo fue encontrado, abrirlo
+            if (!string.IsNullOrEmpty(sPathAyuda))
+            {
+                try
+                {
+                    Help.ShowHelp(null, sPathAyuda); //para abrir archivo si es encontrado 
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show("⚠️ Error al abrir el archivo con Help.ShowHelp(): " + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    System.Diagnostics.Process.Start(sPathAyuda);
+                }
+            }
+            else
+            {
+                MessageBox.Show("❌ ERROR: No se encontró el archivo AyudaNavegador.chm", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error); //mensaje de error
+            }
+        }
+
+
+        /// Busca la carpeta raíz del proyecto "proyectois2k25" comenzando desde una ruta dada
+        /// y subiendo niveles en la jerarquía de directorios hasta encontrarla.
+        private string sFindProjectRootDirectory(string startPath, string stargetFolder)
+        {
+            DirectoryInfo dir = new DirectoryInfo(startPath);
+            // aca estara subiendo niveles o  la jerarquía de directorios hasta encontrar la carpeta "proyectois2k25"
+            while (dir != null)
+            {
+                if (dir.Name.Equals(stargetFolder, StringComparison.OrdinalIgnoreCase))
+                {
+                    return dir.FullName; // Retorna la ruta de la carpeta raíz
+                }
+                dir = dir.Parent; // Subir un nivel en la jerarquía
+            }
+            return null; // Retorna null si no encuentra la carpeta
+        }
+
+        //Busca el archivo (AyudaNavegador.chm) dentro de un directorio y sus subcarpetas.
+        private string sfunFindFileInDirectory(string sDirectory, string sFileName)
         {
             try
             {
-                // Obtener el directorio raíz del proyecto subiendo suficientes niveles
-                string sProjectRootPath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\..\..\..\..\.."));
+                if (Directory.Exists(sDirectory))
 
-                // Combinar la ruta base con la carpeta "Ayuda\AyudaHTML"
-                string sAyudaPath = Path.Combine(sProjectRootPath, "Ayuda", "Ayuda_Navegador", sRutaAyuda);
 
-                // Mostrar la ruta en un MessageBox antes de proceder
-                //MessageBox.Show("Buscando archivo de ayuda en la ruta: " + ayudaPath, "Ruta de Ayuda", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-                // Verificar que el archivo de ayuda exista antes de intentar abrirlo
-                if (File.Exists(sAyudaPath))
                 {
-                    // Mostrar la ayuda utilizando la ruta completa y el índice
-                    Help.ShowHelp(this, sAyudaPath, sIndiceAyuda);
-                    lg.funinsertarabitacora(sIdUsuario, "Vio un documento de ayuda", sTablaPrincipal, sIdAplicacion);
-                }
-                else
-                {
-                    // Mostrar un mensaje de error si el archivo de ayuda no se encuentra
-                    MessageBox.Show("No se encontró el archivo de ayuda en la ruta especificada.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    // Buscar todos los archivos .chm dentro de la carpeta y subcarpetas
+                    string[] sFiles = Directory.GetFiles(sDirectory, "*.chm", SearchOption.AllDirectories);
+                    // Retornar el archivo que coincida con el nombre buscado
+                    return sFiles.FirstOrDefault(file => Path.GetFileName(file).Equals(sFileName, StringComparison.OrdinalIgnoreCase));
                 }
             }
             catch (Exception ex)
             {
-                // Mostrar un mensaje de error en caso de una excepción
-                MessageBox.Show("Ocurrió un error al abrir la ayuda: " + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                Console.WriteLine("Error al abrir la ayuda: " + ex.ToString());
+                MessageBox.Show("⚠️ Error al buscar el archivo: " + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error); // mensaje de error
             }
 
-            BotonesYPermisosSinMensaje();
+            return null; //retorna a null
         }
+
+        //  *****************************************Fin Katy******************************************************************************
         private void button_Paint(object sender, PaintEventArgs e)
         {
             BiselUtil.AplicarBisel(sender as Button, e);

--- a/Codigo/Modulos/Menus/ModernGUI_V3/FormModulos.cs
+++ b/Codigo/Modulos/Menus/ModernGUI_V3/FormModulos.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-//using Capa_Vista_Nominas;    
+using Capa_Vista_Nominas;    
 
 //using Capa_Vista_Banco;      
 //using Capa_Vista_Contabilidad; 
@@ -82,16 +82,16 @@ namespace Interfac_V3
             Aqui debe de agregarse la referencia a nominas
             */
 
-            //frm_principal_nominas nominas = new frm_principal_nominas(UsuarioSesion.GetIdUsuario());
-            //nominas.Show();
+            frm_principal_nominas nominas = new frm_principal_nominas(UsuarioSesion.GetIdUsuario());
+            nominas.Show();
 
 
         }
 
         private void Btn_Logistica_Click(object sender, EventArgs e)
         {
-            Capa_Vista_Logistica.FormPrincipal logistica = new Capa_Vista_Logistica.FormPrincipal(UsuarioSesion.GetIdUsuario());
-            logistica.Show();
+            //Capa_Vista_Logistica.FormPrincipal logistica = new Capa_Vista_Logistica.FormPrincipal(UsuarioSesion.GetIdUsuario());
+            //logistica.Show();
         }
 
         private void Btn_Contabilidad_Click(object sender, EventArgs e)

--- a/Codigo/Modulos/Nominas/Capa_Vista_Nominas/Capa_Vista_Nominas.csproj
+++ b/Codigo/Modulos/Nominas/Capa_Vista_Nominas/Capa_Vista_Nominas.csproj
@@ -44,7 +44,7 @@
       <HintPath>..\Liquidaciones_Empleados\Capa_Vista_Liquidaciones\bin\Debug\Capa_Vista_Liquidaciones.dll</HintPath>
     </Reference>
     <Reference Include="Capa_Vista_Navegador">
-      <HintPath>..\..\..\Componentes\Navegador\Capa_Vista_Navegador\bin\Debug\Capa_Vista_Navegador.dll</HintPath>
+      <HintPath>..\..\..\Componentes\Navegador2_5\Capa_Vista_Navegador\bin\Debug\Capa_Vista_Navegador.dll</HintPath>
     </Reference>
     <Reference Include="Capa_Vista_PercepcionesDeducciones">
       <HintPath>..\..\..\..\..\..\..\..\Escritorio\PercepcionesDeducciones\Capa_Vista_PercepcionesDeducciones\bin\Debug\Capa_Vista_PercepcionesDeducciones.dll</HintPath>

--- a/Codigo/Modulos/Nominas/Capa_Vista_Nominas/frm_principal_nominas.cs
+++ b/Codigo/Modulos/Nominas/Capa_Vista_Nominas/frm_principal_nominas.cs
@@ -236,9 +236,9 @@ namespace Capa_Vista_Nominas
 
         private void Btn_planilla_Click(object sender, EventArgs e)
         {
-            AbrirFormulario<Capa_Vista_Planilla.Frm_GenPlanilla>(); // Pasa el idUsuario
-            Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
-            ocultaSubMenu();
+            //AbrirFormulario<Capa_Vista_Planilla.Frm_GenPlanilla>(); // Pasa el idUsuario
+            //Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
+            //ocultaSubMenu();
         }
 
         private void Btn_anticipo_Click(object sender, EventArgs e)
@@ -257,16 +257,16 @@ namespace Capa_Vista_Nominas
 
         private void Btn_generacionpercep_Click(object sender, EventArgs e)
         {
-            AbrirFormulario<Capa_Vista_PercepcionesDeducciones.frm_generacionpercepciones>(); // Pasa el idUsuario
-            Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
-            ocultaSubMenu();
+            //AbrirFormulario<Capa_Vista_PercepcionesDeducciones.frm_generacionpercepciones>(); // Pasa el idUsuario
+            //Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
+            //ocultaSubMenu();
         }
 
         private void Btn_generaciondeduc_Click(object sender, EventArgs e)
         {
-            AbrirFormulario<Capa_Vista_PercepcionesDeducciones.frm_generaciondeducciones>(); // Pasa el idUsuario
-            Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
-            ocultaSubMenu();
+            //AbrirFormulario<Capa_Vista_PercepcionesDeducciones.frm_generaciondeducciones>(); // Pasa el idUsuario
+            //Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
+            //ocultaSubMenu();
         }
 
         private void Btn_salir_Click(object sender, EventArgs e)
@@ -307,32 +307,32 @@ namespace Capa_Vista_Nominas
 
         private void Btn_procfaltas_Click(object sender, EventArgs e)
         {
-            frm_calculo_faltas falta = new frm_calculo_faltas();
-            falta.Show();
-            ocultaSubMenu();
+            //frm_calculo_faltas falta = new frm_calculo_faltas();
+            //falta.Show();
+            //ocultaSubMenu();
            
         }
 
         private void Btn_procanticipos_Click(object sender, EventArgs e)
         {
-            AbrirFormulario<Capa_Vista_Anticipos.frm_anticipos>();
-            Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
-            ocultaSubMenu(); ;
+            //AbrirFormulario<Capa_Vista_Anticipos.frm_anticipos>();
+            //Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
+            //ocultaSubMenu(); ;
         }
 
         private void Btn_procliquidaciones_Click(object sender, EventArgs e)
         {
-            AbrirFormulario<Capa_Vista_Liquidaciones.Frm_calcular_liquidacion>();
-            Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
-            ocultaSubMenu();
+            //AbrirFormulario<Capa_Vista_Liquidaciones.Frm_calcular_liquidacion>();
+            //Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
+            //ocultaSubMenu();
         }
 
         private void Btn_prochorasextra_Click(object sender, EventArgs e)
         {
             
-            AbrirFormulario<Capa_Vista_HorasExtras.frm_horasextra>(); // Pasa el idUsuario
-            Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
-            ocultaSubMenu();
+            //AbrirFormulario<Capa_Vista_HorasExtras.frm_horasextra>(); // Pasa el idUsuario
+            //Btn_puesto.BackColor = Color.FromArgb(12, 61, 92);
+            //ocultaSubMenu();
         }
 
         #endregion


### PR DESCRIPTION
Anteriormente, el botón de ayuda obtenía la ruta de un archivo de ayuda desde una tabla en la base de datos y utilizaba un formulario para acceder a la ayuda. Esto implicaba dependencias adicionales y una gestión menos eficiente de los archivos de ayuda. 

Cambios Realizados: 
1.	Eliminación de Dependencia con la Base de Datos: Ahora el botón de ayuda no obtiene la ruta desde la base de datos, sino que busca directamente en el sistema de archivos.
2.	Búsqueda Dinámica del Archivo de Ayuda: Se implementó una función que busca la carpeta raiz del proyecto y dentro de ella localiza el archivo AyudaNavegador.chm en sus subcarpetas.
